### PR TITLE
Update apps.md vrouter docs

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -45,7 +45,8 @@ spec:
           - name: in-rules
             default: drop
             rules:
-            - action: accept
+            - id: 10
+              action: accept
               description: Allow Incoming HTTP
               source:
                 address: 192.168.0.0/24
@@ -53,7 +54,8 @@ spec:
                 address: 10.0.0.0/24
                 port: 80
               protocol: tcp
-            - action: accept
+            - id: 20
+              action: accept
               description: Allow Established
               stateful: true
               protocol: all
@@ -137,6 +139,7 @@ spec:
           rules.
 
         * `rules`: list of rules to apply to traffic.
+            * `id`: integer to identify the order of the fules in the set.
 
             * `action`: action to apply to traffic matching rule.
 


### PR DESCRIPTION
The vrouter will fail to implement rules in the router image that is booted if the "id" key is not present in the config. This must be included. The app Golang code should be updated with better errors.